### PR TITLE
Support new qlr syntax for WFS services

### DIFF
--- a/Dataforsyningen/qlr_file.py
+++ b/Dataforsyningen/qlr_file.py
@@ -64,12 +64,14 @@ class QlrFile(object):
                     url_part = part
 
             if url_part:
-                url = url_part.split('=')[1]
+                # url_part is like "url='http://etcetc'"
+                from_ix = url_part.index("=") + 1
+                url = url_part[from_ix:]
                 url = urllib.parse.unquote(url)
                 url_params = dict(
                     urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query)
                 )
-                service = url_params.get("servicename","other")
+                service = url_params.get("servicename", "other")
         return service
 
     def get_maplayer_node(self, id):
@@ -91,4 +93,3 @@ class QlrFile(object):
                     return node
             i += 1
         return None
-


### PR DESCRIPTION
Format changed for WFS datasources which made the parser fail. This PR should fix this problem.

Now it looks like
`url=https://api.dataforsyningen.dk/service?servicename=GeoDanmark60_NOHIST_GML3_DAF&amp;token={{df_token}}`

Where previously it would be more like 
`url=https://api.dataforsyningen.dk/service?servicename%3DGeoDanmark_60_NOHIST_DAF%26token%3D{{df_token}}`

Notice how we now have plain equal char (`=`) after `servicename` inside the url value.