### PR TITLE
Add support for Datafordeler API-key

### DIFF
--- a/Dataforsyningen/dataforsyningen.py
+++ b/Dataforsyningen/dataforsyningen.py
@@ -107,9 +107,7 @@ class Dataforsyningen(object):
     def show_df_settings_warning(self):
         title = self.tr("Dataforsyningen")
 
-        message = self.tr(
-            "Dataforsyningen token or Datafordeler API-key not set or wrong"
-        )
+        message = self.tr("Token or Datafordeler API-key not set or wrong")
         log_message(message)
         self.show_messagebar_linked_to_settings(title, message)
 

--- a/Dataforsyningen/dataforsyningen.py
+++ b/Dataforsyningen/dataforsyningen.py
@@ -107,7 +107,9 @@ class Dataforsyningen(object):
     def show_df_settings_warning(self):
         title = self.tr("Dataforsyningen")
 
-        message = self.tr("Token not set or wrong")
+        message = self.tr(
+            "Dataforsyningen token or Datafordeler API-key not set or wrong"
+        )
         log_message(message)
         self.show_messagebar_linked_to_settings(title, message)
 

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -88,7 +88,14 @@ class DfConfig(QtCore.QObject):
         allowed = {}
         allowed["any_type"] = {"services": []}
         for i in doc:
-            allowed["any_type"]["services"].append(i["name"])
+            # Datafordeler endpoints is shown if there's a apikey added
+            if i["name"].endswith("_DAF") and self.settings.value(
+                "datafordeler_apikey"
+            ):
+                allowed["any_type"]["services"].append(i["name"].removesuffix("_DAF"))
+            # Dataforsyningen endpoints is shown based on call to allowed services
+            else:
+                allowed["any_type"]["services"].append(i["name"])
         self.allowed_df_services = allowed
         if not allowed["any_type"]["services"]:
             self.df_con_error.emit()

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -193,7 +193,7 @@ class DfConfig(QtCore.QObject):
             os.remove(filename)
 
         # Write new version
-        with codecs.open(self.cached_df_qlr_filename, "w", "utf-8") as f:
+        with open(self.cached_df_qlr_filename, "w", "utf-8") as f:
             f.write(contents)
 
     def debug_write_allowed_services(self):
@@ -205,7 +205,7 @@ class DfConfig(QtCore.QObject):
             )
             if os.path.exists(debug_filename):
                 os.remove(debug_filename)
-            with codecs.open(debug_filename, "w", "utf-8") as f:
+            with open(debug_filename, "w", "utf-8") as f:
                 f.write(
                     json.dumps(
                         self.allowed_df_services["any_type"]["services"], indent=2

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -87,14 +87,7 @@ class DfConfig(QtCore.QObject):
         allowed = {}
         allowed["any_type"] = {"services": []}
         for i in doc:
-            # Datafordeler endpoints is shown if there's a apikey added
-            if i["name"].endswith("_DAF") and self.settings.value(
-                "datafordeler_apikey"
-            ):
-                allowed["any_type"]["services"].append(i["name"].removesuffix("_DAF"))
-            # Dataforsyningen endpoints is shown based on call to allowed services
-            else:
-                allowed["any_type"]["services"].append(i["name"])
+            allowed["any_type"]["services"].append(i["name"])
         self.allowed_df_services = allowed
         if not allowed["any_type"]["services"]:
             self.df_con_error.emit()

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -1,5 +1,4 @@
 from builtins import str
-import codecs
 import os
 import datetime
 import traceback
@@ -17,9 +16,7 @@ from qgis.PyQt import QtCore
 from .qlr_file import QlrFile
 
 FILE_MAX_AGE = datetime.timedelta(hours=12)
-DF_SERVICES_URL = (
-    "https://api.dataforsyningen.dk/userpermissions/{{df_token}}"
-)
+DF_SERVICES_URL = "https://api.dataforsyningen.dk/userpermissions/{{df_token}}"
 
 
 def log_message(message):
@@ -27,7 +24,6 @@ def log_message(message):
 
 
 class DfConfig(QtCore.QObject):
-
     df_con_error = QtCore.pyqtSignal()
     df_settings_warning = QtCore.pyqtSignal()
     loaded = QtCore.pyqtSignal()
@@ -195,7 +191,7 @@ class DfConfig(QtCore.QObject):
             os.remove(filename)
 
         # Write new version
-        with open(self.cached_df_qlr_filename, "w", "utf-8") as f:
+        with open(self.cached_df_qlr_filename, "w", encoding="utf-8") as f:
             f.write(contents)
 
     def debug_write_allowed_services(self):
@@ -207,7 +203,7 @@ class DfConfig(QtCore.QObject):
             )
             if os.path.exists(debug_filename):
                 os.remove(debug_filename)
-            with open(debug_filename, "w", "utf-8") as f:
+            with open(debug_filename, "w", encoding="utf-8") as f:
                 f.write(
                     json.dumps(
                         self.allowed_df_services["any_type"]["services"], indent=2

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -60,6 +60,8 @@ class DfConfig(QtCore.QObject):
                 self.df_con_error.emit()
                 self.background_category = None
                 self.categories = []
+            if not self.settings.datafordeler_set():
+                self.df_settings_warning.emit()
             self.debug_write_allowed_services()
         else:
             self.df_settings_warning.emit()

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -52,7 +52,7 @@ class DfConfig(QtCore.QObject):
             + "_dataforsyning_data.qlr"
         )
         self.allowed_df_services = {}
-        if self.settings.dataforsyningen_set():
+        if self.settings.is_dataforsyningen_token_set():
             try:
                 self._request_services()
             except Exception as e:
@@ -60,7 +60,7 @@ class DfConfig(QtCore.QObject):
                 self.df_con_error.emit()
                 self.background_category = None
                 self.categories = []
-            if not self.settings.datafordeler_set():
+            if not self.settings.is_datafordeler_apikey_set():
                 self.df_settings_warning.emit()
             self.debug_write_allowed_services()
         else:

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -222,17 +222,9 @@ class DfConfig(QtCore.QObject):
             pass
 
     def insert_token(self, text):
-        result = text
-        replace_vars = {}
-        replace_vars["df_token"] = self.settings.value("dataforsyningen_token")
-        for i, j in replace_vars.items():
-            result = result.replace("{{" + str(i) + "}}", str(j))
-        return result
+        token = self.settings.value("dataforsyningen_token")
+        return text.replace("{{df_token}}", str(token))
 
     def insert_apikey(self, text):
-        result = text
-        replace_vars = {}
-        replace_vars["datafordeler_apikey"] = self.settings.value("datafordeler_apikey")
-        for i, j in replace_vars.items():
-            result = result.replace("{{" + str(i) + "}}", str(j))
-        return result
+        token = self.settings.value("datafordeler_apikey")
+        return text.replace("{{datafordeler_apikey}}", str(token))

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -50,7 +50,9 @@ class DfConfig(QtCore.QObject):
     def begin_load(self):
         self.cached_df_qlr_filename = (
             self.settings.value("cache_path")
-            + hashlib.md5(self.settings.value("token").encode()).hexdigest()
+            + hashlib.md5(
+                self.settings.value("dataforsyningen_token").encode()
+            ).hexdigest()
             + "_dataforsyning_data.qlr"
         )
         self.allowed_df_services = {}
@@ -95,7 +97,7 @@ class DfConfig(QtCore.QObject):
         if not allowed["any_type"]["services"]:
             self.df_con_error.emit()
             log_message(
-                f"Dataforsyningen returned an empty list of allowed services for token: {self.settings.value('token')}"
+                f"Dataforsyningen returned an empty list of allowed services for token: {self.settings.value('dataforsyningen_token')}"
             )
         # Go on and get QLR
         self._get_qlr_file()
@@ -219,7 +221,7 @@ class DfConfig(QtCore.QObject):
     def insert_token(self, text):
         result = text
         replace_vars = {}
-        replace_vars["df_token"] = self.settings.value("token")
+        replace_vars["df_token"] = self.settings.value("dataforsyningen_token")
         for i, j in replace_vars.items():
             result = result.replace("{{" + str(i) + "}}", str(j))
         return result

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -136,6 +136,7 @@ class DfConfig(QtCore.QObject):
         else:
             response = str(network_reply.readAll(), "utf-8")
             response = self.insert_token(response)
+            response = self.insert_apikey(response)
             self.write_cached_df_qlr(response)
         # Now load and use it
         self._load_config_from_cached_df_qlr()
@@ -224,6 +225,14 @@ class DfConfig(QtCore.QObject):
         result = text
         replace_vars = {}
         replace_vars["df_token"] = self.settings.value("dataforsyningen_token")
+        for i, j in replace_vars.items():
+            result = result.replace("{{" + str(i) + "}}", str(j))
+        return result
+
+    def insert_apikey(self, text):
+        result = text
+        replace_vars = {}
+        replace_vars["datafordeler_apikey"] = self.settings.value("datafordeler_apikey")
         for i, j in replace_vars.items():
             result = result.replace("{{" + str(i) + "}}", str(j))
         return result

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -79,8 +79,7 @@ class DfConfig(QtCore.QObject):
             self.df_con_error.emit()
             log_message(
                 f"Network error getting services from df. Error code : "
-                + str(network_reply.error())
-                + f" ({network_reply.errorString()})"
+                f"{network_reply.error()} ({network_reply.errorString()})"
             )
             return
         response = str(network_reply.readAll(), "utf-8")

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -52,7 +52,7 @@ class DfConfig(QtCore.QObject):
             + "_dataforsyning_data.qlr"
         )
         self.allowed_df_services = {}
-        if self.settings.is_set():
+        if self.settings.dataforsyningen_set():
             try:
                 self._request_services()
             except Exception as e:

--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -155,7 +155,12 @@ class DfConfig(QtCore.QObject):
         for group in groups_with_layers:
             df_category = {"name": group["name"], "selectables": []}
             for layer in group["layers"]:
-                if self.user_has_access(layer["service"]):
+                # Get Datafordeler categories if apikey is set or
+                # check if user has access to Dataforsyningen service
+                if (
+                    self.settings.value("datafordeler_apikey")
+                    and "datafordeler" in layer["provider"]
+                ) or self.user_has_access(layer["service"]):
                     df_category["selectables"].append(
                         {
                             "type": "layer",

--- a/Dataforsyningen/metadata.txt
+++ b/Dataforsyningen/metadata.txt
@@ -14,7 +14,7 @@ qgisMinimumVersion=3.20
 qgisMaximumVersion=4.99
 description=Let adgang til data fra Dataforsyningen (Klimadatastyrelsen) i QGIS.
     Easy access to webservices from Dataforsyningen (Agency for Climate Data) in QGIS.
-version=0.8
+version=0.9
 author=Danish Agency for Climate Data
 email=support@kds.dk
 
@@ -55,7 +55,8 @@ about=See english version below.
 # Recommended items:
 
 # Uncomment the following line and add your changelog:
-changelog: 2026-03-07: version 0.8, support for QGIS 4, added network check, new contact email
+changelog: 2026-06-30: version 0.9, add support for datafordeler endpoint using API-key, replace deprecated codecs.open with open
+    2026-03-07: version 0.8, support for QGIS 4, added network check, new contact email
     2025-02-25: version 0.7, fix for updatede wms endpoints.
     2025-02-06: version 0.6, New email, add support for forvaltning tjenesten 2.0 endpoint move
     2024-10-02: version 0.5, New name, added support for rest services eg. skaermkort_vector_tiles

--- a/Dataforsyningen/mysettings/settings.py
+++ b/Dataforsyningen/mysettings/settings.py
@@ -6,9 +6,7 @@ from qgis.PyQt import QtCore
 from qgis.utils import active_plugins
 from .qgissettingmanager import *
 
-CONFIG_FILE_URL = (
-    "https://qgisplugin.dataforsyningen.dk/qgis_plugin_dataforsyningen_udentoken.qlr"
-)
+CONFIG_FILE_URL = "https://qgisplugin.dataforsyningen.dk/qgis_plugin_dataforsyningen_datafordeler_udentoken.qlr"
 
 
 class Settings(SettingManager):

--- a/Dataforsyningen/mysettings/settings.py
+++ b/Dataforsyningen/mysettings/settings.py
@@ -5,37 +5,43 @@ from qgis.PyQt import QtCore
 
 from qgis.utils import active_plugins
 from .qgissettingmanager import *
-CONFIG_FILE_URL = 'https://qgisplugin.dataforsyningen.dk/qgis_plugin_dataforsyningen_udentoken.qlr'
+
+CONFIG_FILE_URL = (
+    "https://qgisplugin.dataforsyningen.dk/qgis_plugin_dataforsyningen_udentoken.qlr"
+)
+
+
 class Settings(SettingManager):
     settings_updated = QtCore.pyqtSignal()
 
     def __init__(self):
-        SettingManager.__init__(self, 'Dataforsyningen')
-        self.add_setting(String('token', Scope.Global, ''))
-        self.add_setting(Bool('use_custom_file', Scope.Global, False))
-        self.add_setting(String('custom_qlr_file', Scope.Global, ''))
-        self.add_setting(Bool('only_background', Scope.Global, False))
+        SettingManager.__init__(self, "Dataforsyningen")
+        self.add_setting(String("token", Scope.Global, ""))
+        self.add_setting(Bool("use_custom_file", Scope.Global, False))
+        self.add_setting(String("custom_qlr_file", Scope.Global, ""))
+        self.add_setting(Bool("only_background", Scope.Global, False))
         path = QFileInfo(os.path.realpath(__file__)).path()
-        df_path = path + '/df/'
+        df_path = path + "/df/"
         if not os.path.exists(df_path):
             os.makedirs(df_path)
 
-        self.add_setting(String('cache_path', Scope.Global, df_path))
-        self.add_setting(String('df_qlr_url', Scope.Global, CONFIG_FILE_URL))
+        self.add_setting(String("cache_path", Scope.Global, df_path))
+        self.add_setting(String("df_qlr_url", Scope.Global, CONFIG_FILE_URL))
 
     def is_set(self):
         is_set = False
-        if self.value('token'):
+        if self.value("token"):
             is_set = True
-        elif "Kortforsyningen" in active_plugins: # Take the token from kortforsyning plugin
+        elif (
+            "Kortforsyningen" in active_plugins
+        ):  # Take the token from kortforsyning plugin
             s = QtCore.QSettings()
             kortforsyningen_token = s.value("plugins/Kortforsyningen/token")
             if kortforsyningen_token:
-                self.set_value('token', kortforsyningen_token)
+                self.set_value("token", kortforsyningen_token)
                 is_set = True
 
         return is_set
 
     def emit_updated(self):
         self.settings_updated.emit()
-

--- a/Dataforsyningen/mysettings/settings.py
+++ b/Dataforsyningen/mysettings/settings.py
@@ -27,7 +27,7 @@ class Settings(SettingManager):
         self.add_setting(String("cache_path", Scope.Global, df_path))
         self.add_setting(String("df_qlr_url", Scope.Global, CONFIG_FILE_URL))
 
-    def dataforsyningen_set(self):
+    def is_dataforsyningen_token_set(self):
         dataforsyningen_set = False
         if self.value("dataforsyningen_token"):
             dataforsyningen_set = True
@@ -42,7 +42,7 @@ class Settings(SettingManager):
 
         return dataforsyningen_set
 
-    def datafordeler_set(self):
+    def is_datafordeler_apikey_set(self):
         datafordeler_set = False
         if self.value("datafordeler_apikey"):
             datafordeler_set = True

--- a/Dataforsyningen/mysettings/settings.py
+++ b/Dataforsyningen/mysettings/settings.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from qgis.PyQt.QtCore import QFileInfo, QObject
+from qgis.PyQt.QtCore import QFileInfo
 from qgis.PyQt import QtCore
 
 from qgis.utils import active_plugins
@@ -17,6 +17,7 @@ class Settings(SettingManager):
     def __init__(self):
         SettingManager.__init__(self, "Dataforsyningen")
         self.add_setting(String("dataforsyningen_token", Scope.Global, ""))
+        self.add_setting(String("datafordeler_apikey", Scope.Global, ""))
         self.add_setting(Bool("use_custom_file", Scope.Global, False))
         self.add_setting(String("custom_qlr_file", Scope.Global, ""))
         self.add_setting(Bool("only_background", Scope.Global, False))
@@ -28,20 +29,35 @@ class Settings(SettingManager):
         self.add_setting(String("cache_path", Scope.Global, df_path))
         self.add_setting(String("df_qlr_url", Scope.Global, CONFIG_FILE_URL))
 
-    def is_set(self):
-        is_set = False
+    def dataforsyningen_set(self):
+        dataforsyningen_set = False
         if self.value("dataforsyningen_token"):
-            is_set = True
+            dataforsyningen_set = True
         elif (
             "Kortforsyningen" in active_plugins
         ):  # Take the token from kortforsyning plugin
             s = QtCore.QSettings()
             kortforsyningen_token = s.value("plugins/Kortforsyningen/token")
             if kortforsyningen_token:
-                self.set_value("token", kortforsyningen_token)
-                is_set = True
+                self.set_value("dataforsyningen_token", kortforsyningen_token)
+                dataforsyningen_set = True
 
-        return is_set
+        return dataforsyningen_set
+
+    def datafordeler_set(self):
+        datafordeler_set = False
+        if self.value("datafordeler_apikey"):
+            datafordeler_set = True
+        elif (
+            "Kortforsyningen" in active_plugins
+        ):  # Take the apikey from kortforsyning plugin
+            s = QtCore.QSettings()
+            kortforsyningen_apikey = s.value("plugins/Kortforsyningen/apikey")
+            if kortforsyningen_apikey:
+                self.set_value("datafordeler_apikey", kortforsyningen_apikey)
+                datafordeler_set = True
+
+        return datafordeler_set
 
     def emit_updated(self):
         self.settings_updated.emit()

--- a/Dataforsyningen/mysettings/settings.py
+++ b/Dataforsyningen/mysettings/settings.py
@@ -16,7 +16,7 @@ class Settings(SettingManager):
 
     def __init__(self):
         SettingManager.__init__(self, "Dataforsyningen")
-        self.add_setting(String("token", Scope.Global, ""))
+        self.add_setting(String("dataforsyningen_token", Scope.Global, ""))
         self.add_setting(Bool("use_custom_file", Scope.Global, False))
         self.add_setting(String("custom_qlr_file", Scope.Global, ""))
         self.add_setting(Bool("only_background", Scope.Global, False))
@@ -30,7 +30,7 @@ class Settings(SettingManager):
 
     def is_set(self):
         is_set = False
-        if self.value("token"):
+        if self.value("dataforsyningen_token"):
             is_set = True
         elif (
             "Kortforsyningen" in active_plugins

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -80,7 +80,7 @@
           <item>
            <widget class="QGroupBox" name="groupBox">
             <property name="title">
-             <string>Token</string>
+             <string>Dataforsyningen token</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
@@ -97,6 +97,35 @@
               <widget class="QLabel" name="label">
                <property name="text">
                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Find your token to Dataforsyningen&lt;/span&gt;&lt;/a&gt; or &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;create a new token&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Not registered as a user at Dataforsyningen? &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Create user &lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="openExternalLinks">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string>Datafordeleren token</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <widget class="QLineEdit" name="token">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="placeholderText">
+                <string>Enter token to Datafordeleren</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Get a token at &lt;a href="https://datafordeleren.dk"&gt;https://datafordeleren.dk&lt;/a&gt;</string>
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -96,7 +96,7 @@
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Find your token to Dataforsyningen&lt;/span&gt;&lt;/a&gt; or &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;create a new token&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Not registered as a user at Dataforsyningen? &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Create user &lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Find your token to Dataforsyningen&lt;/span&gt;&lt;/a&gt; or &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;create a new token&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Not registered as a user at Dataforsyningen? &lt;a href=&quot;https://dataforsyningen.dk/&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Create user &lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -113,7 +113,7 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QLineEdit" name="token">
+              <widget class="QLineEdit" name="datafordeler_apikey">
                <property name="text">
                 <string/>
                </property>

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -109,7 +109,7 @@
           <item>
            <widget class="QGroupBox" name="groupBox">
             <property name="title">
-             <string>Datafordeleren token</string>
+             <string>Datafordeler token</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
@@ -118,14 +118,14 @@
                 <string/>
                </property>
                <property name="placeholderText">
-                <string>Enter token to Datafordeleren</string>
+                <string>Enter token to Datafordeler</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>Get a token at &lt;a href="https://datafordeleren.dk"&gt;https://datafordeleren.dk&lt;/a&gt;</string>
+                <string>Get a token at &lt;a href="https://portal.datafordeler.dk"&gt;https://portal.datafordeler.dk&lt;/a&gt;</string>
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -84,7 +84,7 @@
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QLineEdit" name="token">
+              <widget class="QLineEdit" name="dataforsyningen_token">
                <property name="text">
                 <string/>
                </property>

--- a/Dataforsyningen/mysettings/settings.ui
+++ b/Dataforsyningen/mysettings/settings.ui
@@ -109,7 +109,7 @@
           <item>
            <widget class="QGroupBox" name="groupBox">
             <property name="title">
-             <string>Datafordeler token</string>
+             <string>Datafordeler API-key</string>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
@@ -118,14 +118,14 @@
                 <string/>
                </property>
                <property name="placeholderText">
-                <string>Enter token to Datafordeler</string>
+                <string>Enter API-key to Datafordeler</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>Get a token at &lt;a href="https://portal.datafordeler.dk"&gt;https://portal.datafordeler.dk&lt;/a&gt;</string>
+                <string>Get a API-key at &lt;a href="https://portal.datafordeler.dk"&gt;https://portal.datafordeler.dk&lt;/a&gt;</string>
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>

--- a/Dataforsyningen/qlr_file.py
+++ b/Dataforsyningen/qlr_file.py
@@ -41,12 +41,27 @@ class QlrFile(object):
             if node.nodeName() == "layer-tree-layer":
                 layer_name = node.toElement().attribute("name")
                 layer_id = node.toElement().attribute("id")
+                layer_source = node.toElement().attribute("source")
+                params = urllib.parse.parse_qs(layer_source)
+
+                if "url" in params:
+                    wms_url = params["url"][0]
+                    layer_provider = urllib.parse.urlparse(wms_url).netloc
+                else:
+                    # Handle case where 'url' parameter is missing
+                    layer_provider = urllib.parse.urlparse(layer_source)
+
                 maplayer_node = self.get_maplayer_node(layer_id)
                 if maplayer_node:
                     service = self.get_maplayer_service(maplayer_node)
                     if service:
                         result.append(
-                            {"name": layer_name, "id": layer_id, "service": service}
+                            {
+                                "name": layer_name,
+                                "id": layer_id,
+                                "service": service,
+                                "provider": layer_provider,
+                            }
                         )
             i += 1
         return result
@@ -71,7 +86,7 @@ class QlrFile(object):
                 url_path = urllib.parse.urlparse(url_only).path
                 url_path = url_path[1:]
                 url_split = url_path.split("/")
-               # i.e. base_url/service/
+                # i.e. base_url/service/
                 if len(url_split) < 2:
                     service = url_path
                 # standard url split

--- a/Dataforsyningen/qlr_file.py
+++ b/Dataforsyningen/qlr_file.py
@@ -88,7 +88,7 @@ class QlrFile(object):
                 url_only = url_part[from_ix:]
                 url_path = urllib.parse.urlparse(url_only).path
                 url_path = url_path[1:]
-                url_split = url_path.split("/")
+                url_split = url_path.lstrip("https://").split("/")
                 # i.e. base_url/service/
                 if len(url_split) < 2:
                     service = url_path

--- a/Dataforsyningen/qlr_file.py
+++ b/Dataforsyningen/qlr_file.py
@@ -48,8 +48,11 @@ class QlrFile(object):
                     wms_url = params["url"][0]
                     layer_provider = urllib.parse.urlparse(wms_url).netloc
                 else:
-                    # Handle case where 'url' parameter is missing
+                    # Handle case where 'url' parameter is missing from source
                     layer_provider = urllib.parse.urlparse(layer_source)
+                    layer_provider = urllib.parse.urlparse(
+                        layer_provider.path.split("url='")[1].split("'")[0]
+                    ).netloc
 
                 maplayer_node = self.get_maplayer_node(layer_id)
                 if maplayer_node:


### PR DESCRIPTION
Adds a new box under Settings -> Dataforsyningen that allows users to add their own API-key
Adding the key will enable Datafordeler layers in the QLR file.