### PR TITLE
gzip bug workaround, use Accept-Encoding: identity

### DIFF
--- a/Dataforsyningen/df_config.py
+++ b/Dataforsyningen/df_config.py
@@ -11,7 +11,7 @@ from qgis.PyQt.QtCore import (
     QUrl,
     QIODevice,
 )
-from qgis.PyQt.QtNetwork import QNetworkReply
+from qgis.PyQt.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.PyQt import QtCore
 from .qlr_file import QlrFile
 
@@ -71,7 +71,9 @@ class DfConfig(QtCore.QObject):
 
     def _request_services(self):
         url_to_get = self.insert_token(DF_SERVICES_URL)
-        self._services_network_fetcher.fetchContent(QUrl(url_to_get))
+        request = QNetworkRequest( QUrl(url_to_get) )
+        request.setRawHeader(b"Accept-Encoding", b"identity")
+        self._services_network_fetcher.fetchContent(request)
 
     def _handle_services_response(self):
         network_reply = self._services_network_fetcher.reply()
@@ -116,7 +118,9 @@ class DfConfig(QtCore.QObject):
 
     def _request_df_qlr_file(self):
         url_to_get = self.settings.value("df_qlr_url")
-        self._qlr_network_fetcher.fetchContent(QUrl(url_to_get))
+        request = QNetworkRequest( QUrl(url_to_get) )
+        request.setRawHeader(b"Accept-Encoding", b"identity")
+        self._qlr_network_fetcher.fetchContent(request)
 
     def _handle_qlr_response(self):
         network_reply = self._qlr_network_fetcher.reply()


### PR DESCRIPTION
`api.dataforsyningen.dk` gateway has a gzip bug that results in invalid gzip in the reply. Some browsers might handle it fine, but QGIS has issues with the malformed reply.

This change makes requests with a HTTP header that disables gzip encoding from the server

This will only affect the initial load (making the plugin at least loadable). Some layers that still requests data from the Dataforsyningen API host might still be affected.

This will fix issue #43
